### PR TITLE
Fixed double body tag on About.html

### DIFF
--- a/About.html
+++ b/About.html
@@ -84,7 +84,7 @@
             </div>
             <hr />
             <footer>
-                <p>&copy; 2017 - <a href="http://www.majorguidancesolutions.com">Major Guidance Solutions</a></p>
+                <p>&copy; 2017. - <a href="http://www.majorguidancesolutions.com">Major Guidance Solutions</a></p>
             </footer>
         </div>
 


### PR DESCRIPTION
This has been a huge problem on all of our HTML files. Although I only added a period after "date" in about since the double body tag was already removed. Remember this is just for practice